### PR TITLE
Disable and stop service/socket if uninstalling

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -1,5 +1,15 @@
 ---
 
+- name: disable and stop rpcbind service and socket if uninstalling rpcbind
+  service:
+    name: '{{ item }}'
+    state: stopped
+    enabled: no
+  with_items:
+    - '{{ rpcbind_service }}'
+    - '{{ rpcbind_socket }}'
+  when: rpcbind_package_state == 'absent'
+
 - name: handle rpcbind packages
   package:
     name: '{{ rpcbind_packages }}'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,4 +5,7 @@ rpcbind_packages:
   - rpcbind
 
 # rpcbind service name
-rpcbind_service: rpcbind
+rpcbind_service: rpcbind.service
+
+# rpcbind socket name
+rpcbind_socket: rpcbind.socket

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,4 +5,7 @@ rpcbind_packages:
   - rpcbind
 
 # rpcbind service name
-rpcbind_service: rpcbind
+rpcbind_service: rpcbind.service
+
+# rpcbind socket name
+rpcbind_socket: rpcbind.socket


### PR DESCRIPTION
##### SUMMARY
The socket appears to continue running even if rpcbind is already uninstalled. This change makes sure there is nothing listening on port 111 after uninstalling rpcbind.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible 2.8.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/ayekat/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.4 (default, Oct  4 2019, 06:57:26) [GCC 9.2.0]
```